### PR TITLE
Cleanup races

### DIFF
--- a/app/helpers/race_date_helper.rb
+++ b/app/helpers/race_date_helper.rb
@@ -4,4 +4,5 @@ module RaceDateHelper
     date.strftime("%b %-d")
   end
 
+
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -6,12 +6,16 @@ class Race < ApplicationRecord
   validates :start_date, presence: true
   validates :end_date, presence: true
 
+  scope :future, -> { where('start_date >= ?', Date.today) }
+
   def self.title_location_list
-    race_list = []
-    all.each do |race|
-      title_and_location = ["#{race.title} - #{race.city}, #{race.state}", race.id]
-      race_list << title_and_location
+    Race.future.map do |race|
+      ["#{race.title} - #{race.city}, #{race.state}", race.id]
     end
-    return race_list
   end
+
+  def future?
+    self.start_date.future?
+  end
+
 end

--- a/app/views/races/show.html.erb
+++ b/app/views/races/show.html.erb
@@ -12,8 +12,9 @@
       <p class="race-dates">
         <%= short_race_date(@race.start_date) %> - <%= short_race_date(@race.end_date) %>
       </p>
-
-      <%= link_to "Register", new_race_registration_path, class: "btn btn-solid-red" %>
+      <% if @race.future? %>
+        <%= link_to "Register", new_race_registration_path, class: "btn btn-solid-red" %>
+      <% end %>
       <%= link_to "Sanction", root_path, class: "btn btn-outline-red" %>
       <br>
       <%= link_to "See others who are registered", race_registrations_path, class: 'small-link' %>

--- a/app/views/shared/_race_tile.html.erb
+++ b/app/views/shared/_race_tile.html.erb
@@ -3,5 +3,7 @@
     <p class="race-dates"><%= short_race_date(race.start_date)%> - <%= short_race_date(race.end_date)%></p>
 
   <%= link_to "Details", race_path(race), class: "btn btn-solid-blue" %>
-  <%= link_to "Register", new_race_registration_path, class: "btn btn-outline-blue" %>
+  <% if race.future? %>
+    <%= link_to "Register", new_race_registration_path, class: "btn btn-outline-blue" %>
+  <% end %>
 </div>

--- a/spec/features/races/user_sees_individual_race_details_spec.rb
+++ b/spec/features/races/user_sees_individual_race_details_spec.rb
@@ -14,9 +14,20 @@ describe "races/:id" do
     expect(page).to have_content("Jul 30")
     expect(page).to have_content("General Information")
     expect(page).to have_content("Where to Stay")
+    expect(page).to have_link("Sanction")
+    expect(page).to have_link("Register")
     expect(page).to have_link("See others who are registered")
     expect(page).to have_content("Upcoming Events")
     expect(page).to have_content(race.details)
     expect(page).to have_content(race.hotel_information)
+  end
+
+  scenario "user does not see registration button for race that has passed" do
+    race = create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
+
+    visit race_path(race)
+
+    expect(page).to have_link("Sanction")
+    expect(page).to_not have_link("Register")
   end
 end

--- a/spec/features/races/user_sees_list_of_all_races_spec.rb
+++ b/spec/features/races/user_sees_list_of_all_races_spec.rb
@@ -26,4 +26,12 @@ describe "/races" do
 
     expect(current_path).to eq(race_path(race))
   end
+  scenario "user does not see registration button for past races" do
+    create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
+
+    visit races_path
+
+    expect(page).to have_link("Details")
+    expect(page).to_not have_link("Register")
+  end
 end

--- a/spec/models/race_spec.rb
+++ b/spec/models/race_spec.rb
@@ -65,5 +65,22 @@ RSpec.describe Race, type: :model do
       expect(list).to eq([["Race for the Kids - Lake Alfred, FL", race_1.id], ["Nationals - DePue, IL", race_2.id]])
       expect(count).to eq(2)
     end
+    it "scopes races to future date" do
+      create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
+      race_2 = create(:race, title: "Nationals", city: "DePue", state: "IL", start_date: '2017-12-21', end_date: '2017-12-23')
+
+      list = Race.title_location_list
+      count = Race.title_location_list.count
+
+      expect(list).to eq([["Nationals - DePue, IL", race_2.id]])
+      expect(count).to eq(1)
+    end
+    it "identifies races as future" do
+      race_1 = create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
+      race_2 = create(:race, title: "Nationals", city: "DePue", state: "IL", start_date: '2017-12-21', end_date: '2017-12-23')
+
+      expect(race_1.future?).to eq(false)
+      expect(race_2.future?).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
* Add scope for `future` races
* Test `future` scope
* Remove races from dropdown option list on race registration form for races with start dates in the past
* Remove "registration" button from race index/show pages for races with start dates in the past