### PR TITLE
Update year_helper logic for default year

### DIFF
--- a/app/helpers/year_helper.rb
+++ b/app/helpers/year_helper.rb
@@ -7,10 +7,8 @@ module YearHelper
   end
 
   def default_year
-    # possibly change because this will fail if there are inteded to be more races
-    # in the season that haven't been to the site yet. Unlikely this scenario would
-    # occur, but it could.
-    if Race.races_this_year.future.empty?
+    # Returns next year if it is after Oct 1 and there are no future races scheduled
+    if Race.races_this_year.future.empty? && (Date.today > Date.parse('October 1'))
       Date.current.next_year.year
     else
       Date.current.year

--- a/spec/factories/races.rb
+++ b/spec/factories/races.rb
@@ -7,8 +7,8 @@ FactoryGirl.define do
     fee_override 50
     longitude 89.3074
     latitude 41.3242
-    start_date "2027-07-26 16:33:57"
-    end_date "2027-07-30 16:33:57"
+    start_date Date.today+7
+    end_date Date.today+9
     sanction Rack::Test::UploadedFile.new(Rails.root() + 'spec/assets/sanction.pdf', 'application/pdf')
     details "These are details about the race"
     hotel_information "This is hotel information about the race"

--- a/spec/features/admin/race_registrations/admin_can_delete_a_race_registration_spec.rb
+++ b/spec/features/admin/race_registrations/admin_can_delete_a_race_registration_spec.rb
@@ -6,7 +6,7 @@ describe "/admin/race_registrations/:id" do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-    race_reg = create(:race_registration)
+    create(:race_registration)
 
     visit admin_race_registrations_path
 

--- a/spec/features/races/user_sees_individual_race_details_spec.rb
+++ b/spec/features/races/user_sees_individual_race_details_spec.rb
@@ -14,8 +14,8 @@ describe "races/:id" do
     expect(page).to have_content(race.state)
     expect(page).to have_content(race.street_address)
     expect(page).to have_content(race.title)
-    expect(page).to have_content("Jul 26")
-    expect(page).to have_content("Jul 30")
+    expect(page).to have_content(race.start_date.strftime("%b %-d"))
+    expect(page).to have_content(race.end_date.strftime("%b %-d"))
     expect(page).to have_content("General Information")
     expect(page).to have_content("Where to Stay")
     expect(page).to have_link("Sanction")
@@ -30,7 +30,7 @@ describe "races/:id" do
     user = create(:user)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-    
+
     race = create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
 
     visit race_path(race)

--- a/spec/features/usts_registrations/user_can_submit_membership_registration_form_spec.rb
+++ b/spec/features/usts_registrations/user_can_submit_membership_registration_form_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe "usts_registrations/new" do
+  let(:year) { Date.current.year }
   before :each do
     user = create(:user)
 
@@ -12,7 +13,7 @@ describe "usts_registrations/new" do
   scenario "user can submit member registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -40,7 +41,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if first name is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[last_name]", with: "Pintozzi"
     fill_in "usts_registration[usts_number]", with: "12345"
@@ -66,7 +67,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if last name is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[usts_number]", with: "12345"
@@ -92,7 +93,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if usts number is missing when submitting usts registration form for racing membership" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -118,7 +119,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if membership type is not selected when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -144,7 +145,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if street address is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -170,7 +171,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if city is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -196,7 +197,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if state is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -222,7 +223,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if zip code is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -248,7 +249,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if liability check mark is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"
@@ -274,7 +275,7 @@ describe "usts_registrations/new" do
   scenario "user sees error message if liability check mark is missing when submitting usts registration form" do
 
     within ('#usts_registration_race_year') do
-      select 2017
+      select year
     end
     fill_in "usts_registration[first_name]", with: "Erin"
     fill_in "usts_registration[last_name]", with: "Pintozzi"

--- a/spec/helpers/year_helper_spec.rb
+++ b/spec/helpers/year_helper_spec.rb
@@ -1,23 +1,67 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe "race date helper" do
-  it "returns the current year if there are future races on the schedule" do
-    create(:race, start_date: Date.tomorrow)
+describe 'race date helper' do
+  include ActiveSupport::Testing::TimeHelpers
+  context 'future races on the schedule' do
+    it 'returns the current year' do
+      create(:race, start_date: Date.tomorrow)
 
-    default_reg_year = helper.default_year
-    expect(default_reg_year).to eq(Date.current.year)
+      default_reg_year = helper.default_year
+      expect(default_reg_year).to eq(Date.current.year)
+    end
   end
-  it "returns the current year if there are future races on the schedule this year and next year" do
-    create(:race, start_date: Date.today)
-    create(:race, start_date: Date.today + 1.year)
+  context 'future races on the schedule this year and next year' do
+    it 'returns the current year' do
+      create(:race, start_date: Date.today)
+      create(:race, start_date: Date.today + 1.year)
 
-    default_reg_year = helper.default_year
-    expect(default_reg_year).to eq(Date.current.year)
+      default_reg_year = helper.default_year
+      expect(default_reg_year).to eq(Date.current.year)
+    end
   end
-  it "returns the next year if there are future races on the schedule but not in this year" do
-    create(:race, start_date: Date.today + 1.year)
+  context 'future races on the schedule but not in this year' do
+    let(:year) { Date.current.year }
+    context 'and it is before Oct 1 of the current year' do
+      before do
+        travel_to Time.zone.local(year, 02, 24)
+      end
+      it 'returns the current year' do
+        create(:race, start_date: Date.today + 1.year)
+        default_reg_year = helper.default_year
+        expect(default_reg_year).to eq(Date.current.year)
+      end
+    end
+    context 'and it is after Oct 1 of the current year' do
+      before do
+        travel_to Time.zone.local(year, 10, 24)
+      end
+      it 'returns the next year' do
+        create(:race, start_date: Date.today + 1.year)
 
-    default_reg_year = helper.default_year
-    expect(default_reg_year).to eq(Date.current.next_year.year)
+        default_reg_year = helper.default_year
+        expect(default_reg_year).to eq(Date.current.next_year.year)
+      end
+    end
+  end
+  context 'no future races on the schedule' do
+    let(:year) { Date.current.year }
+    context 'and it is before Oct 1 of the current year' do
+      before do
+        travel_to Time.zone.local(year, 02, 24)
+      end
+      it 'returns the current year' do
+        default_reg_year = helper.default_year
+        expect(default_reg_year).to eq(Date.current.year)
+      end
+    end
+    context 'and it is after Oct 1 of the current year' do
+      before do
+        travel_to Time.zone.local(year, 10, 24)
+      end
+      it 'returns the next year' do
+        default_reg_year = helper.default_year
+        expect(default_reg_year).to eq(Date.current.next_year.year)
+      end
+    end
   end
 end

--- a/spec/models/race_spec.rb
+++ b/spec/models/race_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe Race, type: :model do
       expect(race_3.registerable?).to eq(false)
     end
     it "identifies races as this year" do
-      race_1 = create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
-      race_2 = create(:race, title: "Nationals", city: "DePue", state: "IL", start_date: '2027-12-21', end_date: '2027-12-23')
+      race_1 = create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: Date.today, end_date: Date.today+1)
+      race_2 = create(:race, title: "Nationals", city: "DePue", state: "IL", start_date: Date.today+500, end_date: Date.today+502)
 
       expect(race_1.race_this_year?).to eq(true)
       expect(race_2.race_this_year?).to eq(false)


### PR DESCRIPTION
This commit updates the default year method to return the current year
it it is before Oct 1 of the current year and there are no future races
scheduled.

Resolves #218