### PR TITLE
Update Race index to only show the current year's schedule

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -2,7 +2,7 @@ class RacesController < ApplicationController
   load_and_authorize_resource only: [:new, :create, :edit, :update]
 
   def index
-    @races = Race.all.order(start_date: :asc)
+    @races = Race.races_this_year.order(start_date: :asc)
   end
 
   def show

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -2,12 +2,16 @@
 
   <h2 class="page-title">Race Schedule</h2>
   <div class="row">
-    <% @races.each do |race| %>
-      <div class="col-md-4">
-        <div class="race-tile">
-          <%= render partial: "shared/race_tile", locals: {race: race} %>
+    <% if @races.present? %>
+      <% @races.each do |race| %>
+        <div class="col-md-4">
+          <div class="race-tile">
+            <%= render partial: "shared/race_tile", locals: {race: race} %>
+          </div>
         </div>
-      </div>
+      <% end %>
+    <% else %>
+      <p class="lead-text"> There are no races scheduled for the current year yet. Check back soon for this year's schedule.</p>
     <% end %>
   </div>
 

--- a/spec/factories/races.rb
+++ b/spec/factories/races.rb
@@ -1,8 +1,14 @@
 FactoryGirl.define do
   factory :race do
-    title "Race for the Kids"
-    street_address "123 Lake Street"
-    city "DePue"
+    sequence :title do |n|
+      "Race Title #{n}"
+    end
+    sequence :street_address do |n|
+      "#{n}123 Lake St"
+    end
+    sequence :city do |n|
+      "City Name#{n}"
+    end
     state "IL"
     fee_override 50
     longitude 89.3074
@@ -12,5 +18,18 @@ FactoryGirl.define do
     sanction Rack::Test::UploadedFile.new(Rails.root() + 'spec/assets/sanction.pdf', 'application/pdf')
     details "These are details about the race"
     hotel_information "This is hotel information about the race"
+
+    trait :this_year_upcoming do
+      start_date Date.today+7
+      end_date Date.today+9
+    end
+    trait :this_year_past do
+      start_date Date.today - 7
+      end_date Date.today - 4
+    end
+    trait :last_year do
+      start_date Date.current.last_year - 3
+      end_date Date.current.last_year
+    end
   end
 end

--- a/spec/features/races/user_sees_list_of_all_races_spec.rb
+++ b/spec/features/races/user_sees_list_of_all_races_spec.rb
@@ -6,8 +6,8 @@ describe "/races" do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    race = create(:race)
-    race2 = Race.create(city: "Denver", state: "CO", start_date: "2017-06-26 16:33:57", end_date: "2017-06-26 16:33:57", title: "New race")
+    race = create(:race, :this_year_upcoming)
+    race2 = Race.create(city: "Denver", state: "CO", start_date: DateTime.now + 2.days, end_date: DateTime.now + 5.days, title: "New race")
 
     visit races_path
 
@@ -23,6 +23,27 @@ describe "/races" do
     expect(page).to have_link("Register")
   end
 
+  scenario "user does not see races from past seasons" do
+    user = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    race = create(:race, :this_year_upcoming)
+    race2 = create(:race, :last_year)
+
+    visit races_path
+
+    expect(page).to have_content(race.city)
+    expect(page).to have_content(race.state)
+    expect(page).to have_content(race.start_date.strftime("%b %-d"))
+    expect(page).to have_content(race.end_date.strftime("%b %-d"))
+    expect(page).to_not have_content(race2.city)
+    expect(page).to_not have_content(race2.start_date.strftime("%b %-d"))
+    expect(page).to_not have_content(race2.end_date.strftime("%b %-d"))
+    expect(page).to have_link("Details")
+    expect(page).to have_link("Register")
+  end
+
   scenario "user can access race details via the index page" do
     race = create(:race)
 
@@ -33,7 +54,7 @@ describe "/races" do
   end
 
   scenario "user does not see registration button for past races" do
-    create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: '2017-04-21', end_date: '2017-04-23')
+    create(:race, :this_year_past)
 
     visit races_path
 
@@ -42,7 +63,7 @@ describe "/races" do
   end
 
   scenario "non-logged in user does not see registration button" do
-    create(:race, title: "Race for the Kids", city: "Lake Alfred", state: "FL", start_date: Date.tomorrow, end_date: Date.tomorrow)
+    create(:race, :this_year_upcoming)
 
     visit races_path
 


### PR DESCRIPTION
Before this change, it would show all races in chronological order
including those from the previous season.