### PR TITLE
Depue class fees

### DIFF
--- a/app/models/race_registration.rb
+++ b/app/models/race_registration.rb
@@ -87,6 +87,7 @@ class RaceRegistration < ApplicationRecord
        if boat_class.class_name == "KPro"
          return 25
        elsif boat_class.class_name.downcase.include?('depue only')
+         # needs to be tested and probably rewritten to be less fragile
          boat_class.registration_fee
        else
        race.fee_override

--- a/app/models/race_registration.rb
+++ b/app/models/race_registration.rb
@@ -86,6 +86,8 @@ class RaceRegistration < ApplicationRecord
      if race.fee_override?
        if boat_class.class_name == "KPro"
          return 25
+       elsif boat_class.class_name.downcase.include?('depue only')
+         boat_class.registration_fee
        else
        race.fee_override
        end


### PR DESCRIPTION
Allow for boat class fees to override race override fees for Depue only. Yes this is as fragile as it sounds and still needs to be tested when time allows.